### PR TITLE
Update cli.rb

### DIFF
--- a/lib/pleaserun/cli.rb
+++ b/lib/pleaserun/cli.rb
@@ -1,4 +1,3 @@
-
 require "pleaserun/namespace"
 require "clamp"
 require "cabin"
@@ -82,7 +81,7 @@ exact process launcher to target:
 Let's do another example. How about running nagios in systemd, but we
 want to abort if the nagios config is invalid?
 
-    % pleaserun -t systemd \
+    % pleaserun -p systemd \
       --prestart "/usr/sbin/nagios -v /etc/nagios/nagios.cfg" \
       /usr/sbin/nagios /etc/nagios/nagios.cfg
 


### PR DESCRIPTION
`pleaserun -t systemd` -> `pleaserun -p systemd` in --help

Assuming the former was meant as "-t = target" but got implemented as "platform" instead?
