### PR TITLE
requires ohai gem to do system detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "cabin"
 gem "stud"
 gem "mustache"
 gem "insist"
+gem "ohai"
 
 # For testing
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       rspec (~> 2.14)
     hitimes (1.2.1)
     insist (1.0.0)
+    ipaddress (0.8.0)
     listen (2.4.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -32,8 +33,20 @@ GEM
       atomic (~> 1.0)
       avl_tree (~> 1.1.2)
       hitimes (~> 1.1)
+    mixlib-cli (1.4.0)
+    mixlib-config (2.1.0)
+    mixlib-log (1.6.0)
+    mixlib-shellout (1.3.0)
     mustache (0.99.5)
     net-ssh (2.8.0)
+    ohai (6.20.0)
+      ipaddress
+      mixlib-cli
+      mixlib-config
+      mixlib-log
+      mixlib-shellout
+      systemu (~> 2.5.2)
+      yajl-ruby
     peach (0.5.1)
     pry (0.9.12.4)
       coderay (~> 1.0)
@@ -54,8 +67,10 @@ GEM
     stud (0.0.17)
       ffi
       metriks
+    systemu (2.5.2)
     thor (0.18.1)
     timers (1.1.0)
+    yajl-ruby (1.2.0)
 
 PLATFORMS
   ruby
@@ -68,6 +83,7 @@ DEPENDENCIES
   insist
   mustache
   net-ssh
+  ohai
   peach
   rspec
   stud

--- a/pleaserun.gemspec
+++ b/pleaserun.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "pleaserun"
-  spec.version = "0.0.1"
+  spec.version = "0.0.2"
   spec.summary = "pleaserun"
   spec.description = "pleaserun"
   spec.license = "Apache 2.0"
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "stud"
   spec.add_dependency "mustache"
   spec.add_dependency "insist"
+  spec.add_dependency "ohai", "~> 6.20" # used for host detection
 
   spec.files = files
   spec.require_paths << "lib"


### PR DESCRIPTION
:heart: 

without requiring the ohai gem I get the following:

```
vagrant@pleaserun:/tmp/redis-2.8.6$ sudo pleaserun --install /tmp/redis/bin/redis-server
/var/lib/gems/1.9.1/gems/pleaserun-0.0.1/lib/pleaserun/detector.rb:29:in `detect': PleaseRun::Detector::UnknownSystem (PleaseRun::Detector::UnknownSystem)
    from /var/lib/gems/1.9.1/gems/pleaserun-0.0.1/lib/pleaserun/cli.rb:102:in `execute'
    from /var/lib/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    from /var/lib/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:125:in `run'
    from /var/lib/gems/1.9.1/gems/pleaserun-0.0.1/bin/pleaserun:7:in `<top (required)>'
    from /usr/local/bin/pleaserun:19:in `load'
    from /usr/local/bin/pleaserun:19:in `<main>'
vagrant@pleaserun:/tmp/redis-2.8.6$
```
