### PR TITLE
make template location relative to script

### DIFF
--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -101,7 +101,7 @@ class PleaseRun::Platform::Base
 
   # Get the template path for this platform.
   def template_path
-    return File.join("templates", platform)
+    return File.join(File.dirname(__FILE__), "../../../templates", platform)
   end # def template_path
 
   def render_template(name)


### PR DESCRIPTION
- this allows it to work in a vendored ruby directory.
- allows using from source called from a difference cwd
