### PR TITLE
[FIX] Readme.md formatting (typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With pleaserun, you can generate the following launchers/scripts/whatever:
 * runit
 * sysv init
 
-Want more? It's easy to add things. [File an issue](issues/) and ask away!
+Want more? It's easy to add things. [File an issue](../../issues/) and ask away!
 
 ## Installation
 


### PR DESCRIPTION
Added spaces to `ls /tmp/redis/bin` code snippet in Readme.md for propper markdown formatting. Helps with better visualization/grasping of Readme file.
