### PR TITLE
Create init.d.sh

### DIFF
--- a/templates/upstart/0.6.5/init.d.sh
+++ b/templates/upstart/0.6.5/init.d.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "This job runs via upstart, invoking upstart now..."
+exec initctl $1 {{name}}


### PR DESCRIPTION
Fixes missing init.d.sh file. Copied from the 1.5 directory.

```
/usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/platform/base.rb:127:in `render_template': Could not find template file for 'init.d.sh'. Tried all of these: ["/usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/platform/../../../templates/upstart/0.6.5/init.d.sh", "/usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/platform/../../../templates/upstart/default/init.d.sh", "/usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/platform/../../../templates/upstart/init.d.sh"] (PleaseRun::Platform::Base::InvalidTemplate)
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/platform/upstart.rb:10:in `block in files'
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/installer.rb:18:in `each'
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/installer.rb:18:in `install_files'
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/cli.rb:175:in `run_human'
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/lib/pleaserun/cli.rb:127:in `execute'
    from /usr/lib64/ruby/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    from /usr/lib64/ruby/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:125:in `run'
    from /usr/lib64/ruby/gems/1.9.1/gems/pleaserun-0.0.5/bin/pleaserun:7:in `<top (required)>'
    from /usr/bin/pleaserun:23:in `load'
    from /usr/bin/pleaserun:23:in `<main>'
```
