### PR TITLE
Add stop parameter

### DIFF
--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -130,8 +130,9 @@ class PleaseRun::Platform::Base
     validate { |v| v == "ulimited" || v.to_i > 0 }
   end
 
-
   attribute :prestart, "A command to execute before starting and restarting. A failure of this command will cause the start/restart to abort. This is useful for health checks, config tests, or similar operations."
+
+  attribute :stop, "A command to execute to stop the service. A failure of this command will cause the stop to abort. Useful when killing process is not enough."
 
   def initialize(target_version)
     configurable_setup

--- a/templates/systemd/default/program.service
+++ b/templates/systemd/default/program.service
@@ -2,7 +2,7 @@
 {{#description}}
 Description={{{ description }}}
 {{/description}}
- 
+
 [Service]
 Type=simple
 User={{{ user }}}
@@ -11,6 +11,9 @@ ExecStart={{{program}}} {{{shell_args}}}
 {{#prestart}}
 ExecStartPre=/lib/systemd/system/{{{name}}}-prestart.sh
 {{/prestart}}
+{{#stop}}
+ExecStop={{{stop}}}
+{{/stop}}
 Restart=always
 
 [Install]


### PR DESCRIPTION
A command to execute to stop the service. A failure of this command will cause the stop to abort. Useful when killing process is not enough.
