### PR TITLE
Add amazon AMI to detector.

### DIFF
--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -8,6 +8,7 @@ class PleaseRun::Detector
 
   # A mapping of of [os, version] => [runner, version]
   MAPPING = {
+    ["amazon", "2014.09"] => ["upstart", "0.6.5"],
     ["arch", "rolling"] => ["systemd", "default"],
     ["centos", "5"] => ["sysv", "lsb-3.1"],
     ["centos", "6"] => ["upstart", "0.6.5"],


### PR DESCRIPTION
Resolve #67 I think.  I have no idea how to ruby but this is a pretty simple change.  I just can't test it.  I did confirm that a new AMI thinks it is amazon 2014.09 and that the upstart version is 0.6.5.