### PR TITLE
Change Amazon to use sysv

### DIFF
--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -8,7 +8,7 @@ class PleaseRun::Detector
 
   # A mapping of of [os, version] => [runner, version]
   MAPPING = {
-    ["amazon", "2014.09"] => ["upstart", "0.6.5"],
+    ["amazon", "2014.09"] => ["sysv", "lsb-3.1"],
     ["arch", "rolling"] => ["systemd", "default"],
     ["centos", "5"] => ["sysv", "lsb-3.1"],
     ["centos", "6"] => ["upstart", "0.6.5"],


### PR DESCRIPTION
Having now spent a few days hacking around after filing #67, I think the majority of things I've installed so far (e.g. yum packages of elasticsearch, monit, and others) on my Amazon machine use `sysv: lsb-3.1`. For consistency and familiarity to users who are used to typing `service xyz start` instead of `start xyz`, I think it'd make sense to swap to sysv?

I've successfully just installed a couple of services using sysv too.