### PR TITLE
Ensure SysV init script returns sensible error codes

### DIFF
--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -108,7 +108,7 @@ status() {
       # so it makes it quite awkward to use in this case.
       return 0
     else
-      return 2 # program is dead but pid file exists
+      return 1 # program is dead but pid file exists
     fi
   else
     return 3 # program is not running

--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -23,6 +23,8 @@ program={{#escaped}}{{{ program }}}{{/escaped}}
 args={{{ escaped_args }}}
 pidfile="/var/run/$name.pid"
 
+[ -x "$program" ] || exit 0
+
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
 

--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -189,9 +189,22 @@ case "$1" in
     ;;
   restart) 
     {{#prestart}}if [ "$PRESTART" != "no" ] ; then
-      prestart || exit $?
+      prestart || exit 2
     fi{{/prestart}}
-    stop && start 
+    stop
+    case $? in
+      0|1)
+        start
+        case $? in
+          0) exit 0 ;;
+          *) exit 1 ;;
+        esac
+        ;;
+      *)
+        # Failed to stop
+        exit 1
+        ;;
+    esac
     ;;
   *)
     echo "Usage: $SCRIPTNAME {start|force-start|stop|force-start|force-stop|status|restart}" >&2

--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -7,8 +7,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:          {{{ name }}}
-# Required-Start:    $remote_fs $syslog
-# Required-Stop:     $remote_fs $syslog
+# Required-Start:    $remote_fs $syslog $network $named
+# Required-Stop:     $remote_fs $syslog $network $named
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: {{{ one_line_description }}}

--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -38,6 +38,17 @@ emit() {
 }
 
 start() {
+  {{! Return
+       0 if daemon has been started
+       1 if daemon was already running
+       2 if daemon could not be started
+  }}
+
+  status && {
+    emit "$name is already running"
+    return 1
+  }
+
   {{! I don't use 'su' here to run as a different user because the process 'su'
       stays as the parent, causing our pidfile to contain the pid of 'su' not the
       program we intended to run. Luckily, the 'chroot' program on OSX, FreeBSD, and Linux
@@ -53,7 +64,7 @@ start() {
   {{#prestart}}
   if [ "$PRESTART" != "no" ] ; then
     # If prestart fails, abort start.
-    prestart || return $?
+    prestart || return 2
   fi
   {{/prestart}}
 
@@ -146,17 +157,7 @@ case "$1" in
     PRESTART=no
     exec "$0" start
     ;;
-  start)
-    status
-    code=$?
-    if [ $code -eq 0 ]; then
-      emit "$name is already running"
-      exit $code
-    else
-      start
-      exit $?
-    fi
-    ;;
+  start) start ;;
   stop) stop ;;
   force-stop) force_stop ;;
   status) 


### PR DESCRIPTION
The proposed modifications are just for discussion. The script would become Debian-centric. In Debian, we don't follow LSB 3.1 for the exit code (see [bug 208010](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=208010)). I know that Redhat follows more closely LSB 3.1.

For example, in Debian, we just exit 0 if the daemon doesn't exist. The script being part of a package, this means that the package has been removed but the script is still here (being a conffile). We don't consider it an error to start/stop a non existing daemon. We just exit with 0. In RHEL, they exit with 5 (as stated in LSB 3.1). Maybe the init script is removed with the package in their case, so it would be a sensible case.

The change to status applies to both Debian and RHEL.

I don't know exactly what RHEL does for start/stop/restart. In Debian, we do as I have put in the comments, notably for restart which is handled specially to abstract the return code.

I think it would be far easier to generate a SysV script for RHEL and one for Debian. You would be able to use the helper commands/function from each distribution and cleanly integrate. In Debian, the skeleton to be used is this [one](http://sources.debian.net/src/sysvinit/2.88dsf-41%2Bdeb7u1/debian/src/initscripts/etc/init.d/skeleton/). For my own projects, I also have something else for RHEL, but I cannot vouch this is the best way to do that.

I also think that `force-start` and `force-stop` are odd ducks. `force-stop` should just be stop. In Debian, this is common to kill with KILL after 30 seconds. This would improve `restart`.
