### PR TITLE
Attempt to allow RHEL5(and derivatives) which use a old chroot 

### DIFF
--- a/templates/sysv/lsb-3.1/init.sh
+++ b/templates/sysv/lsb-3.1/init.sh
@@ -60,7 +60,7 @@ start() {
 
   # Run the program!
   {{#nice}}nice -n "$nice" \{{/nice}}
-  chroot --userspec "$user":"$group" "$chroot" sh -c "
+  sh -c "
     {{{ulimit_shell}}}
     cd \"$chdir\"
     exec \"$program\" $args


### PR DESCRIPTION
Please see https://github.com/jordansissel/pleaserun/issues/49 for more details.

This is a attempt to fix the init scripts for RHEL5 (and friends).

Luke