### PR TITLE
add fedora 21 to list of known versions

### DIFF
--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -19,6 +19,7 @@ class PleaseRun::Detector
     ["fedora", "18"] => ["systemd", "default"],
     ["fedora", "19"] => ["systemd", "default"],
     ["fedora", "20"] => ["systemd", "default"],
+    ["fedora", "21"] => ["systemd", "default"],
     ["mac_os_x", "10.10"] => ["launchd", "10.9"],
     ["mac_os_x", "10.8"] => ["launchd", "10.9"],
     ["mac_os_x", "10.9"] => ["launchd", "10.9"],


### PR DESCRIPTION
I ran into issues with autodetection on my Fedora 21 server:

````
[root@zubkoland ~]# pleaserun --user phenny /opt/phenny/phenny
/usr/local/rvm/gems/ruby-head/gems/pleaserun-0.0.16/lib/pleaserun/detector.rb:50:in `detect': fedora 21 (PleaseRun::Detector::UnknownSystem)
        from /usr/local/rvm/gems/ruby-head/gems/pleaserun-0.0.16/lib/pleaserun/cli.rb:140:in `setup_defaults'
        from /usr/local/rvm/gems/ruby-head/gems/pleaserun-0.0.16/lib/pleaserun/cli.rb:107:in `execute'
        from /usr/local/rvm/gems/ruby-head/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
        from /usr/local/rvm/gems/ruby-head/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
        from /usr/local/rvm/gems/ruby-head/gems/pleaserun-0.0.16/bin/pleaserun:6:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-head/bin/pleaserun:23:in `load'
        from /usr/local/rvm/gems/ruby-head/bin/pleaserun:23:in `<main>'
        from /usr/local/rvm/gems/ruby-head/bin/ruby_executable_hooks:15:in `eval'
        from /usr/local/rvm/gems/ruby-head/bin/ruby_executable_hooks:15:in `<main>'
````

No additional problems encountered after adding an additional definition for Fedora version 21.