### PR TITLE
Fixed improper mustache templating

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pleaserun (0.0.12)
+    pleaserun (0.0.16)
       cabin (> 0)
       clamp
       insist
@@ -14,7 +14,7 @@ GEM
     cabin (0.7.1)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    clamp (0.6.4)
+    clamp (1.0.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     ffi (1.9.6)
@@ -104,7 +104,7 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
-    stud (0.0.19)
+    stud (0.0.22)
     systemu (2.6.5)
     thor (0.19.1)
     timers (4.0.1)

--- a/templates/upstart/1.5/init.conf
+++ b/templates/upstart/1.5/init.conf
@@ -9,8 +9,10 @@ nice {{{nice}}}
 {{/nice}}
 {{#chroot}}
 chroot {{{chroot}}}
-{{#chroot}}
+{{/chroot}}
+{{#chdir}}
 chdir {{{chdir}}}
+{{/chdir}}
 {{#limit_coredump}}
 limit core {{{limit_coredump}}} {{{limit_coredump}}}
 {{/limit_coredump}}
@@ -36,7 +38,7 @@ limit nproc {{{limit_user_processes}}} {{{limit_user_processes}}}
 {{/limit_user_processes}}
 {{#limit_physical_memory}}
 limit rss {{{limit_physical_memory}}} {{{limit_physical_memory}}}
-{{#limit_physical_memory}}
+{{/limit_physical_memory}}
 #limit rtprio <softlimit> <hardlimit>
 #limit sigpending <softlimit> <hardlimit>
 {{#limit_stack_size}}


### PR DESCRIPTION
Not sure how this didn't get into the original pull request. There were a couple of places where the mustache block was terminated with `{{#` instead of `{{/` 

I had made the changes right around when I made the original pull request but must not have been updated correctly. Just noticed it when I was merging your update back into my repo.

This pull request has the fix and has also been merged with your master.