### PR TITLE
Add the ability to set env variables in upstart scripts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pleaserun (0.0.12)
+    pleaserun (0.0.16)
       cabin (> 0)
       clamp
       insist
@@ -14,7 +14,7 @@ GEM
     cabin (0.7.1)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    clamp (0.6.4)
+    clamp (1.0.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     ffi (1.9.6)
@@ -104,7 +104,7 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
-    stud (0.0.19)
+    stud (0.0.22)
     systemu (2.6.5)
     thor (0.19.1)
     timers (4.0.1)

--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -134,7 +134,6 @@ class PleaseRun::Platform::Base
     validate do |envs|
       insist { envs }.is_a?(Array)
       envs.each { |e| insist { e }.is_a?(Hash) }
-      envs.each { |e| insist {e.keys.sort == %w(key value) }
     end
   end
   

--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -130,6 +130,14 @@ class PleaseRun::Platform::Base
     validate { |v| v == "ulimited" || v.to_i > 0 }
   end
 
+  attribute :envs, "Env key/value pairs to insert into init script (Upstart only)" do
+    validate do |envs|
+      insist { envs }.is_a?(Array)
+      envs.each { |e| insist { e }.is_a?(Hash) }
+      envs.each { |e| insist {e.keys.sort == %w(key value) }
+    end
+  end
+  
   # TODO(sissel): Move this into the sysv platform
   attribute :sysv_log_path, "The destination for log output. If ending with a trailing / is treated like a directory with path/<name>.log. This setting only currently works with the sysv platform. This flag may go away at any time because I'm not sure we can easily abstract the logging feature across different service managers. Upstart and systemd don't even have this concept.",
     :default => "/var/log/"

--- a/templates/upstart/1.5/init.conf
+++ b/templates/upstart/1.5/init.conf
@@ -2,6 +2,10 @@ description     "{{{ description }}}"
 start on filesystem or runlevel [2345]
 stop on runlevel [!2345]
 
+{{#envs}}
+env {{key}}={{value}}
+{{/envs}}
+
 respawn
 umask {{{umask}}}
 {{#nice}}

--- a/templates/upstart/1.5/init.conf
+++ b/templates/upstart/1.5/init.conf
@@ -13,8 +13,10 @@ nice {{{nice}}}
 {{/nice}}
 {{#chroot}}
 chroot {{{chroot}}}
-{{#chroot}}
+{{/chroot}}
+{{#chdir}}
 chdir {{{chdir}}}
+{{/chdir}}
 {{#limit_coredump}}
 limit core {{{limit_coredump}}} {{{limit_coredump}}}
 {{/limit_coredump}}
@@ -40,7 +42,7 @@ limit nproc {{{limit_user_processes}}} {{{limit_user_processes}}}
 {{/limit_user_processes}}
 {{#limit_physical_memory}}
 limit rss {{{limit_physical_memory}}} {{{limit_physical_memory}}}
-{{#limit_physical_memory}}
+{{/limit_physical_memory}}
 #limit rtprio <softlimit> <hardlimit>
 #limit sigpending <softlimit> <hardlimit>
 {{#limit_stack_size}}


### PR DESCRIPTION
Needed a way to pass in environment variables (env in upstart file).

This only works for upstart