### PR TITLE
Don't break systems on apt-get upgrade

### DIFF
--- a/templates/user/linux/default/remover.sh
+++ b/templates/user/linux/default/remover.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 user_check() {
   getent passwd "$1" > /dev/null 2>&1
@@ -8,6 +9,12 @@ user_remove() {
   userdel "$1"
 }
 
-if user_check "{{{ name }}}" ; then
-  user_remove "{{{ name }}}"
-fi
+case $1 in
+    purge)
+        if user_check "{{{ name }}}" ; then
+          user_remove "{{{ name }}}"
+        fi
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
postrm is also executed on upgrades, this broke upgrades if the user was
currently in use, leaving apt in a broken state. After the upgrade the user
would be recreated, but might get a different uid which breaks permissions of
the packaged application.

This patches prevents user deletion unless the package is purged.