### PR TITLE
Fix self.detect_facter

### DIFF
--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -66,7 +66,7 @@ class PleaseRun::Detector
   def self.detect_ohai
     require "ohai/system"
     ohai = Ohai::System.new
-    # TODO(sissel): Loading all plugins takes a long time (seconds). 
+    # TODO(sissel): Loading all plugins takes a long time (seconds).
     # TODO(sissel): Figure out how to load just the platform plugin correctly.
     ohai.all_plugins
 
@@ -79,8 +79,8 @@ class PleaseRun::Detector
   def self.detect_facter
     require "facter"
 
-    platform = Facter.fact["operatingsystem"]
-    version = Facter.fact["operatingsystemrelease"]
+    platform = Facter.value(:operatingsystem)
+    version = Facter.value(:operatingsystemrelease)
     return platform, normalize_version(platform, version)
   end # def detect_facter
 
@@ -99,7 +99,4 @@ class PleaseRun::Detector
     return version
   end
 
-  def self.detect_facter
-    require "facter"
-  end
 end


### PR DESCRIPTION
There were two instances of this method, the second empty.

The first was calling in an apparently older format.  The newer calls should be symbols:

```
jruby-1.7.25 :005 > Facter.list
 => [:kernel, :domain, :network_docker0, :network_eth0, :network_lo, :network_veth9c88ef2, 
:puppetversion, :blockdevice_sda_size, :blockdevice_sda_vendor, :blockdevice_sda_model, 
:blockdevice_sdb_size, :blockdevice_sdb_vendor, :blockdevice_sdb_model, :blockdevices, :id, 
:hardwaremodel, :ipaddress6, :lsbmajdistrelease, :lsbdistdescription, :iphostnumber, :partitions, 
:processors, :architecture, :operatingsystem, :os, :processor0, :processor1, :processor2, :processor3, 
:processor4, :processor5, :processor6, :processor7, :processorcount, :processor, :uptime_seconds, 
:virtual, :is_virtual, :zonename, :ps, :fqdn, :osfamily, :gid, :kernelversion, :operatingsystemmajrelease, 
:uniqueid, :operatingsystemrelease, :lsbdistid, :system_uptime, :netmask, :ec2_metadata, :ec2_userdata, 
:kernelmajversion, :kernelrelease, :is_rsc, :rsc_region, :rsc_instance_id, :hardwareisa, :sshdsakey, 
:sshfp_dsa, :sshrsakey, :sshfp_rsa, :sshecdsakey, :sshfp_ecdsa, :sshed25519key, :sshfp_ed25519, 
:dhcp_servers, :zfs_version, :uptime_days, :rubyversion, :selinux, :selinux_enforced, 
:selinux_policyversion, :selinux_current_mode, :selinux_config_mode, :selinux_config_policy, :gce, 
:ipaddress, :lsbdistrelease, :rubysitedir, :memorysize, :memoryfree, :swapsize, :swapfree, :swapsize_mb, 
:swapfree_mb, :memorysize_mb, :memoryfree_mb, :swapencrypted, :cfkey, :lsbminordistrelease, 
:augeasversion, :lsbrelease, :hostname, :zpool_version, :rubyplatform, :lsbdistcodename, :interfaces, 
:ipaddress_docker0, :ipaddress6_docker0, :macaddress_docker0, :netmask_docker0, :mtu_docker0, 
:ipaddress_eth0, :ipaddress6_eth0, :macaddress_eth0, :netmask_eth0, :mtu_eth0, :ipaddress_lo, 
:ipaddress6_lo, :macaddress_lo, :netmask_lo, :mtu_lo, :ipaddress_veth9c88ef2, 
:ipaddress6_veth9c88ef2, :macaddress_veth9c88ef2, :netmask_veth9c88ef2, :mtu_veth9c88ef2, :vlans, 
:uptime_hours, :timezone, :macaddress, :facterversion, :uptime, :filesystems, :xendomains, 
:physicalprocessorcount, :path, :system32]
```

fixes #99