### PR TITLE
Downcase the platform

### DIFF
--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -79,7 +79,7 @@ class PleaseRun::Detector
   def self.detect_facter
     require "facter"
 
-    platform = Facter.value(:operatingsystem)
+    platform = Facter.value(:operatingsystem).downcase
     version = Facter.value(:operatingsystemrelease)
     return platform, normalize_version(platform, version)
   end # def detect_facter


### PR DESCRIPTION
It came back as "Ubuntu," which fails to compare to "ubuntu" in the
map.