### PR TITLE
Allow for systemd path used by SuSE variants

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -3,6 +3,8 @@
 == 0.0.22 (May 16, 2016)
   * Platform detection mechanisms now look for systemd in both /lib/systemd and
     /usr/lib/systemd in order to accommodate SuSE linux variants.
+  * Fix an edge case where systemd path exists in Ubuntu 12.04, but no systemd
+    binary exists, causing an error
 
 == 0.0.21 (May 16, 2016)
   * Platform detection mechanism now looks for evidence that a given platform

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,9 +1,9 @@
 = Pleaserun Changes and Releases
 
 == 0.0.22 (May 16, 2016)
-  * Platform detection mechanisms now look for systemd in both /lib/systemd and
-    /usr/lib/systemd in order to accommodate SuSE linux variants.
-  * Fix an edge case where systemd path exists in Ubuntu 12.04, but no systemd
+  * Platform detection mechanisms now look for systemd in /usr/lib/systemd in
+    order to accommodate more linux variants.
+  * Fix an edge case where systemd path exists in Ubuntu, but no systemd
     binary exists, causing an error
 
 == 0.0.21 (May 16, 2016)

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,5 +1,9 @@
 = Pleaserun Changes and Releases
 
+== 0.0.22 (May 16, 2016)
+  * Platform detection mechanisms now look for systemd in both /lib/systemd and
+    /usr/lib/systemd in order to accommodate SuSE linux variants.
+
 == 0.0.21 (May 16, 2016)
   * Platform detection mechanism now looks for evidence that a given platform
     is available (files, executables, etc).  The previous mechanism used facter
@@ -11,7 +15,7 @@
 
 == 0.0.19 (May 6, 2016)
   * Fix bug in OS detection
-  
+
 == 0.0.18 (May 6, 2016)
   * Support newer Facter api (Aaron Mildtenstein)
 
@@ -30,7 +34,7 @@
   * cli: New flag --sysv-log-path. This lets you set the path for the sysv platform to log its output.
 
 == 0.0.4 (March 5, 2014)
-  * cli: Autodetect OSX and use launchd 
+  * cli: Autodetect OSX and use launchd
 
 == Prior versions?
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -3,8 +3,8 @@
 == 0.0.22 (May 16, 2016)
   * Platform detection mechanisms now look for systemd in /usr/lib/systemd in
     order to accommodate more linux variants.
-  * Fix an edge case where systemd path exists in Ubuntu, but no systemd
-    binary exists, causing an error
+  * Deploy systemd unit files to /etc/systemd/system as that seems to be the only
+    path searched by all systems using systemd.
 
 == 0.0.21 (May 16, 2016)
   * Platform detection mechanism now looks for evidence that a given platform

--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -27,6 +27,11 @@ module PleaseRun::Detector
     # Expect a certain directory
     return false unless File.directory?("/lib/systemd/system") || File.directory?("/usr/lib/systemd/system")
 
+    # Verify presence of systemctl before proceeding.  This catches an edge
+    # case in ubuntu 12.04 where the systemctl path exists, but no binary
+    out, status = execute([ "which", "systemctl" ])
+    return false unless status.success?
+
     # Check the version. If `systemctl` fails, systemd isn't available.
     out, status = execute([ "systemctl", "--version" ])
     return false unless status.success?

--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -25,14 +25,14 @@ module PleaseRun::Detector
 
   def detect_systemd
     # Expect a certain directory
-    return false unless File.directory?("/lib/systemd/system")
+    return false unless File.directory?("/lib/systemd/system") || File.directory?("/usr/lib/systemd/system")
 
     # Check the version. If `systemctl` fails, systemd isn't available.
     out, status = execute([ "systemctl", "--version" ])
     return false unless status.success?
 
     # version is the last word on the first line of the --version output
-    version = out.split("\n").first.split(/\s+/).last 
+    version = out.split("\n").first.split(/\s+/).last
     ["systemd", version]
   end
 
@@ -50,7 +50,7 @@ module PleaseRun::Detector
 
   def detect_sysv
     return false unless File.directory?("/etc/init.d")
-    
+
     # TODO(sissel): Do more specific testing.
     ["sysv", "lsb-3.1"]
   end

--- a/lib/pleaserun/detector.rb
+++ b/lib/pleaserun/detector.rb
@@ -25,12 +25,7 @@ module PleaseRun::Detector
 
   def detect_systemd
     # Expect a certain directory
-    return false unless File.directory?("/lib/systemd/system") || File.directory?("/usr/lib/systemd/system")
-
-    # Verify presence of systemctl before proceeding.  This catches an edge
-    # case in ubuntu 12.04 where the systemctl path exists, but no binary
-    out, status = execute([ "which", "systemctl" ])
-    return false unless status.success?
+    return false unless File.directory?("/usr/lib/systemd")
 
     # Check the version. If `systemctl` fails, systemd isn't available.
     out, status = execute([ "systemctl", "--version" ])

--- a/lib/pleaserun/platform/systemd.rb
+++ b/lib/pleaserun/platform/systemd.rb
@@ -13,9 +13,10 @@ class PleaseRun::Platform::Systemd < PleaseRun::Platform::Base
       raise PleaseRun::Configurable::ValidationError, "In systemd, the program must be a full path. You gave '#{program}'."
     end
 
+    File.directory?("/usr/lib/systemd/system") ? usr = "/usr" : usr = ""
     return Enumerator::Generator.new do |enum|
-      enum.yield(safe_filename("/lib/systemd/system/{{{ name }}}.service"), render_template("program.service"))
-      enum.yield(safe_filename("/lib/systemd/system/{{{ name }}}-prestart.sh"), render_template("prestart.sh"), 0755) if prestart
+      enum.yield(safe_filename("#{usr}/lib/systemd/system/{{{ name }}}.service"), render_template("program.service"))
+      enum.yield(safe_filename("#{usr}/lib/systemd/system/{{{ name }}}-prestart.sh"), render_template("prestart.sh"), 0755) if prestart
     end
   end # def files
 

--- a/lib/pleaserun/platform/systemd.rb
+++ b/lib/pleaserun/platform/systemd.rb
@@ -13,10 +13,9 @@ class PleaseRun::Platform::Systemd < PleaseRun::Platform::Base
       raise PleaseRun::Configurable::ValidationError, "In systemd, the program must be a full path. You gave '#{program}'."
     end
 
-    File.directory?("/usr/lib/systemd/system") ? usr = "/usr" : usr = ""
     return Enumerator::Generator.new do |enum|
-      enum.yield(safe_filename("#{usr}/lib/systemd/system/{{{ name }}}.service"), render_template("program.service"))
-      enum.yield(safe_filename("#{usr}/lib/systemd/system/{{{ name }}}-prestart.sh"), render_template("prestart.sh"), 0755) if prestart
+      enum.yield(safe_filename("/etc/systemd/system/{{{ name }}}.service"), render_template("program.service"))
+      enum.yield(safe_filename("/etc/systemd/system/{{{ name }}}-prestart.sh"), render_template("prestart.sh"), 0755) if prestart
     end
   end # def files
 

--- a/pleaserun.gemspec
+++ b/pleaserun.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |spec|
   files = File.read(__FILE__)[/^__END__$.*/m].split("\n")[1..-1]
 
   spec.name = "pleaserun"
-  spec.version = "0.0.21"
+  spec.version = "0.0.22"
   spec.summary = "pleaserun"
   spec.description = "pleaserun"
   spec.license = "Apache 2.0"

--- a/templates/systemd/default/program.service
+++ b/templates/systemd/default/program.service
@@ -2,7 +2,7 @@
 {{#description}}
 Description={{{ description }}}
 {{/description}}
- 
+
 [Service]
 Type=simple
 User={{{ user }}}
@@ -14,7 +14,7 @@ EnvironmentFile=-/etc/default/{{{name}}}
 EnvironmentFile=-/etc/sysconfig/{{{name}}}
 ExecStart={{{program}}} {{{shell_args}}}
 {{#prestart}}
-ExecStartPre=/lib/systemd/system/{{{name}}}-prestart.sh
+ExecStartPre=/etc/systemd/system/{{{name}}}-prestart.sh
 {{/prestart}}
 Restart=always
 WorkingDirectory={{{chdir}}}


### PR DESCRIPTION
Which is /usr/lib/systemd instead of /lib/systemd

Apologies for the empty line/space corrections picked up by my editor (Atom).

fixes #103