### PR TITLE
Generic logging

### DIFF
--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -130,10 +130,14 @@ class PleaseRun::Platform::Base
     validate { |v| v == "ulimited" || v.to_i > 0 }
   end
 
-  # TODO(sissel): Move this into the sysv platform
-  attribute :sysv_log_path, "The destination for log output. If ending with a trailing / is treated like a directory with path/<name>.log. This setting only currently works with the sysv platform. This flag may go away at any time because I'm not sure we can easily abstract the logging feature across different service managers. Upstart and systemd don't even have this concept.",
-    :default => "/var/log/"
+  attribute :log_directory, "The destination for log output",
+    :default => "/var/log"
 
+  attribute :log_file_stderr, "Name of log file for stderr. Will default to NAME-stderr.log",
+    :default => nil
+
+  attribute :log_file_stdout, "Name of log file for stdout. Will default to NAME-stderr.log",
+    :default => nil
 
   attribute :prestart, "A command to execute before starting and restarting. A failure of this command will cause the start/restart to abort. This is useful for health checks, config tests, or similar operations."
 
@@ -191,15 +195,19 @@ class PleaseRun::Platform::Base
     return []
   end # def install_actions
 
-  def sysv_log
-    if sysv_log_directory?
-      File.join(sysv_log_path, name)
-    else
-      sysv_log_path
-    end
+  def log_path
+    File.join(log_directory.chomp("/"), name)
   end
 
-  def sysv_log_directory?
-    return sysv_log_path.end_with?("/")
+  def log_path_stderr
+    filename = "#{name}-stderr.log"
+    filename = log_file_stderr unless log_file_stderr.nil?
+    File.join(log_directory.chomp("/"), filename)
+  end
+
+  def log_path_stdout
+    filename = "#{name}-stdout.log"
+    filename = log_file_stdout unless log_file_stdout.nil?
+    File.join(log_directory.chomp("/"), filename)
   end
 end # class PleaseRun::Base

--- a/spec/pleaserun/platform/base_spec.rb
+++ b/spec/pleaserun/platform/base_spec.rb
@@ -25,28 +25,103 @@ describe PleaseRun::Platform::Base do
       insist { subject.group } == "root"
     end
 
-    context "#sysv_log" do
+    it "#log_directory should be /var/log" do
+      insist { subject.log_directory } == "/var/log"
+    end
+
+    context "#log_path" do
       let(:name) { "fancy" }
       before { subject.name = name }
 
       context "default" do
         it "should be in /var/log" do
-          expect(subject.sysv_log).to(be == "/var/log/#{name}")
+          expect(subject.log_path).to(be == "/var/log/#{name}")
         end
       end
 
-      context "when given a directory" do
-        let(:path) { "/tmp/" }
-        before { subject.sysv_log_path = path }
+      context "when given a directory without trailing slash" do
+        let(:path) { "/tmp" }
+        before { subject.log_directory = path }
         it "should be <path>/<name>" do
-          expect(subject.sysv_log).to(be == File.join(path, subject.name))
+          expect(subject.log_path).to(be == File.join(path, name))
         end
       end
-      context "when given a path" do
-        let(:path) { "/some/path" }
-        before { subject.sysv_log_path = path }
-        it "should be exactly the path given" do
-          expect(subject.sysv_log).to(be == path)
+
+      context "when given a directory with trailing slash" do
+        let(:path) { "/tmp/" }
+        before { subject.log_directory = path }
+        it "should be <path>/<name>" do
+          expect(subject.log_path).to(be == File.join(path, name))
+        end
+      end
+    end
+
+    context "#log_path_stderr" do
+      let(:name) { "fancy" }
+      before { subject.name = name }
+
+      context "default" do
+        it "should be in /var/log" do
+          expect(subject.log_path_stderr).to(be == "/var/log/#{name}-stderr.log")
+        end
+      end
+
+      context "when given a directory without trailing slash" do
+        let(:path) { "/tmp" }
+        before { subject.log_directory = path }
+        it "should be <path>/<name>-stderr.log" do
+          expect(subject.log_path_stderr).to(be == File.join(path, "#{name}-stderr.log"))
+        end
+      end
+
+      context "when given a directory with trailing slash" do
+        let(:path) { "/tmp/" }
+        before { subject.log_directory = path }
+        it "should be <path>/<name>-stderr.log" do
+          expect(subject.log_path_stderr).to(be == File.join(path, "#{name}-stderr.log"))
+        end
+      end
+
+      context "when specified as an argument it should use the name" do
+        let(:log_file_stderr) { "#{name}-stderr" }
+        before { subject.log_file_stderr = log_file_stderr }
+        it "should be <path>/<name>-stderr" do
+          expect(subject.log_path_stderr).to(be == File.join(path, log_file_stderr))
+        end
+      end
+    end
+
+    context "#log_path_stdout" do
+      let(:name) { "fancy" }
+      before { subject.name = name }
+
+      context "default" do
+        it "should be in /var/log" do
+          expect(subject.log_path_stdout).to(be == "/var/log/#{name}-stdout.log")
+        end
+      end
+
+      context "when given a directory without trailing slash" do
+        let(:path) { "/tmp" }
+        before { subject.log_directory = path }
+        it "should be <path>/<name>-stdout.log" do
+          expect(subject.log_path_stdout).to(be == File.join(path, "#{name}-stdout.log"))
+        end
+      end
+
+      context "when given a directory with trailing slash" do
+        let(:path) { "/tmp/" }
+        before { subject.log_directory = path }
+        it "should be <path>/<name>-stdout.log" do
+          expect(subject.log_path_stdout).to(be == File.join(path, "#{name}-stdout.log"))
+        end
+      end
+
+      context "when specified as an argument it should use the name" do
+        let(:log_file_stdout) { "#{name}-stdout" }
+        before { subject.log_file_stdout = log_file_stdout }
+        it "should be <path>/<name>-stdout" do
+          expect(subject.log_path_stdout).to(be == File.join(path, log_file_stdout))
         end
       end
     end

--- a/templates/launchd/default/program.plist
+++ b/templates/launchd/default/program.plist
@@ -10,8 +10,8 @@
       {{{xml_args}}}
     </array>
     <key>KeepAlive</key> <true/>
-    <key>StandardOutPath</key> <string>/var/log/{{name}}.out</string>
-    <key>StandardErrorPath</key> <string>/var/log/{{name}}.err</string>
+    <key>StandardOutPath</key> <string>{{ log_path_stdout }}</string>
+    <key>StandardErrorPath</key> <string>{{ log_path_stderr }}</string>
     <!-- Things to implement eventually.
     <key>UserName</key><string>{{{ user }}}</string>
     <key>GroupName</key><string>{{{ group }}}</string>

--- a/templates/runit/log
+++ b/templates/runit/log
@@ -1,4 +1,4 @@
 #! /bin/sh
 
-exec svlogd -tt /var/log/{{ name }}
+exec svlogd -tt {{ log_path }}
 

--- a/templates/sysv/default/init.sh
+++ b/templates/sysv/default/init.sh
@@ -43,12 +43,10 @@ start() {
       program we intended to run. Luckily, the 'chroot' program on OSX, FreeBSD, and Linux
       all support switching users and it invokes execve immediately after chrooting. }}
 
-  {{#sysv_log_directory?}}
   # Ensure the log directory is setup correctly.
-  [ ! -d "{{{sysv_log_path}}}" ] && mkdir "{{{sysv_log_path}}}"
-  chown "$user":"$group" "{{{sysv_log_path}}}"
-  chmod 755 "{{{sysv_log_path}}}"
-  {{/sysv_log_directory?}}
+  [ ! -d "{{{ log_directory }}}" ] && mkdir "{{{ log_directory }}}"
+  chown "$user":"$group" "{{{ log_directory }}}"
+  chmod 755 "{{{ log_directory }}}"
 
   {{#prestart}}
   if [ "$PRESTART" != "no" ] ; then
@@ -66,7 +64,7 @@ start() {
     {{{ulimit_shell}}}
     cd \"$chdir\"
     exec \"$program\" $args
-  " >> {{{ sysv_log }}}.stdout 2>> {{{ sysv_log }}}.stderr &
+  " >> {{{ log_path_stdout }}} 2>> {{{ log_path_stderr }}} &
 
   # Generate the pidfile from here. If we instead made the forked process
   # generate it there will be a race condition between the pidfile writing

--- a/templates/upstart/0.6.5/init.conf
+++ b/templates/upstart/0.6.5/init.conf
@@ -35,5 +35,4 @@ pre-start script
 end script
 {{/prestart}}
 
-{{! TODO(sissel): Support logging }}
-exec chroot --userspec {{{user}}}:{{{group}}} {{{chroot}}} {{{program}}} {{{shell_args}}}
+exec chroot --userspec {{{user}}}:{{{group}}} {{{chroot}}} {{{program}}} {{{shell_args}}} >> {{ log_path_stdout }} 2>> {{ log_path_stderr }}

--- a/templates/upstart/default/init.conf
+++ b/templates/upstart/default/init.conf
@@ -44,7 +44,6 @@ limit stack {{{limit_stack_size}}} {{{limit_stack_size}}}
 {{/limit_stack_size}}
 setuid {{{user}}}
 setgid {{{group}}}
-console log # log stdout/stderr to /var/log/upstart/
 
 {{#prestart}}
 pre-start script
@@ -60,4 +59,4 @@ pre-start script
 end script
 {{/prestart}}
 
-exec {{{program}}} {{{shell_args}}}
+exec chroot --userspec {{{user}}}:{{{group}}} {{{chroot}}} {{{program}}} {{{shell_args}}} >> {{ log_path_stdout }} 2>> {{ log_path_stderr }}


### PR DESCRIPTION
This pull request should add generic logging support to all adapters. It does drop `sysv_log_path` as an option, so is not completely BC, and thus should warrant at least a minor release.