### PR TITLE
Add support for environment variables to Upstart 0.6.5

### DIFF
--- a/templates/upstart/0.6.5/init.conf
+++ b/templates/upstart/0.6.5/init.conf
@@ -35,4 +35,8 @@ pre-start script
 end script
 {{/prestart}}
 
-exec chroot --userspec {{{user}}}:{{{group}}} {{{chroot}}} {{{program}}} {{{shell_args}}} >> {{ log_path_stdout }} 2>> {{ log_path_stderr }}
+script
+  [ -r {{{default_file}}} ] && . {{{default_file}}}
+  [ -r {{{sysconfig_file}}} ] && . {{{sysconfig_file}}}
+  exec chroot --userspec {{{user}}}:{{{group}}} {{{chroot}}} {{{program}}} {{{shell_args}}} >> {{ log_path_stdout }} 2>> {{ log_path_stderr }}
+end script


### PR DESCRIPTION
Support for environment variables in Upstart 0.6.5 was ommitted in #111 but it is key to using Upstart on Centos 6.

Will close #115.