### PR TITLE
Add option to export env variables to daemon

### DIFF
--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -107,6 +107,18 @@ class PleaseRun::Platform::Base
     end
   end
 
+  attribute :export_variables, "Env variable names to export to the daemon", :multivalued => true do
+    munge do |export_variables|
+      if export_variables.is_a?(String)
+        export_variables = [export_variables]
+      end
+      export_variables
+    end
+    validate do |export_variables|
+      insist { export_variables }.is_a?(Array)
+    end
+  end
+
   attribute :nice, "The nice level to add to this program before running" do
     validate do |nice|
       insist { nice }.is_a?(Fixnum)

--- a/templates/sysv/default/init.sh
+++ b/templates/sysv/default/init.sh
@@ -45,6 +45,10 @@ KILL_ON_STOP_TIMEOUT=0
 [ -r {{{default_file}}} ] && . {{{default_file}}}
 [ -r {{{sysconfig_file}}} ] && . {{{sysconfig_file}}}
 
+{{#export_variables}}
+export {{{.}}}
+{{/export_variables}}
+
 [ -z "$nice" ] && nice=0
 
 trace() {


### PR DESCRIPTION
This change allows environment variables to be exported in the sysv init script.  This allows `/etc/default/$name` or `/etc/sysconfig/$name` to function in a manner similar to systemd (minus the end-user's ability to set whatever environment variables they want).

The motivation for this change is to allow `NODE_OPTIONS` to be specified in `/etc/default/kibana` for the Kibana 4 Debian/Ubuntu packages, even when using sysvinit.  (There are still some supported versions of Ubuntu with sysvinit.)