### PR TITLE
Set a very large 'kill timeout' by default.

### DIFF
--- a/templates/systemd/default/program.service
+++ b/templates/systemd/default/program.service
@@ -22,5 +22,9 @@ WorkingDirectory={{{chdir}}}
 {{/nice}}{{#limit_open_files}}LimitNOFILE={{{limit_open_files}}}
 {{/limit_open_files}}
 
+# When stopping, how long to wait before giving up and sending SIGKILL?
+# Keep in mind that SIGKILL on a process can cause data loss.
+TimeoutStopSec=infinity
+
 [Install]
 WantedBy=multi-user.target

--- a/templates/upstart/default/init.conf
+++ b/templates/upstart/default/init.conf
@@ -45,6 +45,14 @@ limit stack {{{limit_stack_size}}} {{{limit_stack_size}}}
 setuid {{{user}}}
 setgid {{{group}}}
 
+# Set a really really large kill timeout
+# By default, upstart has a kill timeout of 5 seconds.
+# If the program is being stopped, but hasn't finished by the time this 'kill
+# timeout' has expired, then upstart will destroy the process with SIGKILL.
+# SIGKILL is a way to cause data loss, so we try to disable this feature by
+# default.
+kill timeout 99999999
+
 {{#prestart}}
 pre-start script
   {{{ prestart }}}


### PR DESCRIPTION
This is to avoid default SIGKILL behavior which will cause data loss and other problems.

upstart defaults to 5 seconds before SIGKILL is used. systemd seems to default to 90 seconds (or 180? It's hard to tell from the docs).