### PR TITLE
Don't change log dir perms if it already exists in sysv init

### DIFF
--- a/templates/sysv/default/init.sh
+++ b/templates/sysv/default/init.sh
@@ -67,9 +67,11 @@ start() {
       all support switching users and it invokes execve immediately after chrooting. }}
 
   # Ensure the log directory is setup correctly.
-  [ ! -d "{{{ log_directory }}}" ] && mkdir "{{{ log_directory }}}"
-  chown "$user":"$group" "{{{ log_directory }}}"
-  chmod 755 "{{{ log_directory }}}"
+  if [ ! -d "{{{ log_directory }}}" ]; then 
+    mkdir "{{{ log_directory }}}"
+    chown "$user":"$group" "{{{ log_directory }}}"
+    chmod 755 "{{{ log_directory }}}"
+  fi
 
   {{#prestart}}
   if [ "$PRESTART" != "no" ] ; then


### PR DESCRIPTION
The default log directory is /var/log, without this patch its easy to accidentally change its perms. This patch also makes sense because in the case of an extant directory the user may have intentionally changed its ownership and this init script will surprisingly revert that.