### PR TITLE
runit: fix for: Invalid value '"/service"' for attribute 'service_path'

### DIFF
--- a/lib/pleaserun/platform/runit.rb
+++ b/lib/pleaserun/platform/runit.rb
@@ -6,8 +6,8 @@ require "pleaserun/platform/base"
 # Learn what runit is here: http://smarden.org/runit/
 class PleaseRun::Platform::Runit < PleaseRun::Platform::Base
   attribute :service_path, "The path runit service directory",
-            :default => "/service" do |path|
-    validate do
+            :default => "/service"
+    validate do do |path|
       insist { path }.is_a?(String)
     end
   end


### PR DESCRIPTION
The `runit` helper is broken. Not sure why nobody else has not seen / noticed this issue in all of this time! Anyhow,

This commit fixes the following bug:

```sh
$ pleaserun --name teleport --platform runit --no-install-actions --install-prefix runit --chdir /var/lib/teleport /z_out_binpath/teleport start --config z_cfg_file
Traceback (most recent call last):
	16: from /usr/local/bin/pleaserun:23:in `<main>'
	15: from /usr/local/bin/pleaserun:23:in `load'
	14: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/bin/pleaserun:6:in `<top (required)>'
	13: from /var/lib/gems/2.5.0/gems/clamp-1.0.1/lib/clamp/command.rb:133:in `run'
	12: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/cli.rb:114:in `run'
	11: from /var/lib/gems/2.5.0/gems/clamp-1.0.1/lib/clamp/command.rb:68:in `run'
	10: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/cli.rb:122:in `execute'
	 9: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/cli.rb:220:in `load_platform'
	 8: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 7: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 6: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/platform/runit.rb:7:in `<top (required)>'
	 5: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/platform/runit.rb:8:in `<class:Runit>'
	 4: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/configurable.rb:66:in `attribute'
	 3: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/configurable.rb:66:in `new'
	 2: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/configurable.rb:159:in `initialize'
	 1: from /var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/configurable.rb:168:in `validate'
/var/lib/gems/2.5.0/gems/pleaserun-0.0.30/lib/pleaserun/configurable.rb:171:in `rescue in validate': Invalid value '"/service"' for attribute 'service_path' (PleaseRun::Configurable::FacetDSL is not a String) (PleaseRun::Configurable::ValidationError)
```

Please take / merge. I am guessing it will also be necessary to increment and push out these changes with a new gem version? If so please don't forget to also update the version of this gem required by `fpm`...


https://github.com/jordansissel/fpm/blob/master/fpm.gemspec#L58

I am reading here that `~>` means that the version needs to be less than `0.1.0`. For example if you increment the patch version from `0.0.29` to `0.0.30`. Then fpm will take it / pick up the next new version.