### PR TITLE
chore: remove 'mustache' pin

### DIFF
--- a/pleaserun.gemspec
+++ b/pleaserun.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cabin", ">0" # for logging. apache 2 license
   spec.add_dependency "clamp"
   spec.add_dependency "stud"
-  spec.add_dependency "mustache", "0.99.8"
+  spec.add_dependency "mustache"
   spec.add_dependency "insist"
   spec.add_dependency "dotenv"
   #spec.add_dependency "ohai", "~> 6.20" # used for host detection


### PR DESCRIPTION
Ruby 2.x are end of life.

Latest mustache 1.1.1 looks to be working just fine in my superficial
teseting on Ubuntu 22.04
