### PR TITLE
Pin dotenv to v2.x to allow older versions of ruby to use this library.

### DIFF
--- a/lib/pleaserun/version.rb
+++ b/lib/pleaserun/version.rb
@@ -1,3 +1,3 @@
 module PleaseRun
-  VERSION = "0.0.32"
+  VERSION = "0.0.33"
 end

--- a/pleaserun.gemspec
+++ b/pleaserun.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "stud"
   spec.add_dependency "mustache", "0.99.8"
   spec.add_dependency "insist"
-  spec.add_dependency "dotenv"
+  spec.add_dependency "dotenv", "~> 2"
   #spec.add_dependency "ohai", "~> 6.20" # used for host detection
 
   spec.files = files


### PR DESCRIPTION
I tested this on rocky 8 w/ ruby 2.5 and things seem to work

References: https://github.com/jordansissel/fpm/issues/2048