### PR TITLE
Ruby 3.4 compatibility updates

### DIFF
--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -109,7 +109,7 @@ class PleaseRun::Platform::Base
 
   attribute :nice, "The nice level to add to this program before running" do
     validate do |nice|
-      insist { nice }.is_a?(Fixnum)
+      insist { nice }.is_a?(Integer)
     end
     munge do |nice|
       next nice.to_i

--- a/spec/pleaserun/cli_spec.rb
+++ b/spec/pleaserun/cli_spec.rb
@@ -18,7 +18,7 @@ describe PleaseRun::CLI do
 
     it "should write files there" do
       [ "/etc", "/etc/init.d", "/etc/init.d/#{name}" ].each do |path|
-        expect(File).to be_exists(File.join(output, path))
+        expect(File).to exist(File.join(output, path))
       end
     end
   end

--- a/spec/pleaserun/configurable_spec.rb
+++ b/spec/pleaserun/configurable_spec.rb
@@ -68,7 +68,8 @@ describe PleaseRun::Configurable::Facet do
       facet.value = "hello"
       insist { facet.value } == "hello"
       facet.value = { "foo" => "bar" }
-      insist { facet.value } == '{"foo"=>"bar"}'
+      expect(facet.value).to include('"foo"')
+      expect(facet.value).to include('"bar"')
       insist { count } == 3
     end
 

--- a/spec/pleaserun/platform/base_spec.rb
+++ b/spec/pleaserun/platform/base_spec.rb
@@ -29,6 +29,11 @@ describe PleaseRun::Platform::Base do
       insist { subject.log_directory } == "/var/log"
     end
 
+    it "#nice should accept integer values" do
+      subject.nice = 19
+      insist { subject.nice } == 19
+    end
+
     context "#log_path" do
       let(:name) { "fancy" }
       before { subject.name = name }


### PR DESCRIPTION
This commit makes the required changes to get all tests passing on ruby 3.4. Specifically:
1. Updates Fixnum (deprecated) to Integer
2. Updates deprecated exists rspec matcher
3. Fixes assertion that was brittle based on relying on hash -> string
4. Adds explicit test for 1

I have run the tests locally on both ruby 3.4 and 2.6 to ensure backward compat.

Closes https://github.com/jordansissel/pleaserun/issues/142
Related: https://github.com/elastic/logstash/issues/19156